### PR TITLE
chore: Add scaffolding.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.go]
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+- Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct. By adopting this Code of Conduct,
+project maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do
+not follow or enforce the Code of Conduct may be permanently removed from the
+project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc], version
+1.2.0, available at https://contributor-covenant.org/version/1/2/0/.
+
+[cc]: http://contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Want to contribute? Great! First, read this page (including the small print at
+the end).
+
+### Before you contribute
+
+Before we can use your code, you must sign the Google Individual
+[Contributor License Agreement][cla] (CLA), which you can do online. The CLA is
+necessary mainly because you own the copyright to your changes, even after your
+contribution becomes part of our codebase, so we need your permission to use
+and distribute your code.
+
+We also need to be sure of various other things—for instance, that you'll tell
+us if you know that your code infringes on other people's patents. You don't
+have to sign the CLA until after you've submitted your code for review and a
+member has approved it, but you must do it before we can put your code into our
+codebase.
+
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose.
+
+### The small print
+
+Contributions made by corporations are covered by a different agreement than
+the one above: the [Software Grant and Corporate CLA][corp-cla].
+
+[cla]: https://cla.developers.google.com/about/google-individual
+[corp-cla]: https://cla.developers.google.com/about/google-corporate


### PR DESCRIPTION
- The code of conduct is based on the internal version, but with
  reformatted Markdown to be consistent with other repositories
  (copied outright from github.com/googleapis/api-linter).
- The contributing is based on github.com/googleapis/gax-go,
  but removed the reference to breaking changes, which appears to
  be Kokoro based.
- `.editorconfig` is taken from the linter and primarily seems
  to configure GitHub.

Change-Id: I780fe4bccafd256ecd21ad35f641333516c69b82