### PR TITLE
chore: refactor Go CI off docker

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,12 +5,12 @@ branchProtectionRules:
   - pattern: main
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - unit-tests (golang:1.11)
-      - unit-tests (golang:1.12)
-      - unit-tests (golang:1.13)
-      - unit-tests (golang:1.14)
-      - unit-tests (golang:1.15)
-      - unit-tests (golang:1.16)
+      - ci / unit-tests (1.11)
+      - ci / unit-tests (1.12)
+      - ci / unit-tests (1.13)
+      - ci / unit-tests (1.14)
+      - ci / unit-tests (1.15)
+      - ci / unit-tests (1.16)
       - lint
       - cla/google
     requiredApprovingReviewCount: 1

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,13 +5,13 @@ branchProtectionRules:
   - pattern: main
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - ci / unit-tests (1.11)
-      - ci / unit-tests (1.12)
-      - ci / unit-tests (1.13)
-      - ci / unit-tests (1.14)
-      - ci / unit-tests (1.15)
-      - ci / unit-tests (1.16)
-      - ci / lint
+      - unit-tests (1.11)
+      - unit-tests (1.12)
+      - unit-tests (1.13)
+      - unit-tests (1.14)
+      - unit-tests (1.15)
+      - unit-tests (1.16)
+      - lint
       - cla/google
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,13 +5,13 @@ branchProtectionRules:
   - pattern: main
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - ci / unit-tests (1.11) (pull_request)
-      - ci / unit-tests (1.12) (pull_request)
-      - ci / unit-tests (1.13) (pull_request)
-      - ci / unit-tests (1.14) (pull_request)
-      - ci / unit-tests (1.15) (pull_request)
-      - ci / unit-tests (1.16) (pull_request)
-      - ci / lint (pull_request)
+      - ci / unit-tests (1.11)
+      - ci / unit-tests (1.12)
+      - ci / unit-tests (1.13)
+      - ci / unit-tests (1.14)
+      - ci / unit-tests (1.15)
+      - ci / unit-tests (1.16)
+      - ci / lint
       - cla/google
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,7 @@ branchProtectionRules:
       - ci / unit-tests (1.14)
       - ci / unit-tests (1.15)
       - ci / unit-tests (1.16)
-      - lint
+      - ci / lint
       - cla/google
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,13 +5,13 @@ branchProtectionRules:
   - pattern: main
     isAdminEnforced: true
     requiredStatusCheckContexts:
-      - ci / unit-tests (1.11)
-      - ci / unit-tests (1.12)
-      - ci / unit-tests (1.13)
-      - ci / unit-tests (1.14)
-      - ci / unit-tests (1.15)
-      - ci / unit-tests (1.16)
-      - ci / lint
+      - ci / unit-tests (1.11) (pull_request)
+      - ci / unit-tests (1.12) (pull_request)
+      - ci / unit-tests (1.13) (pull_request)
+      - ci / unit-tests (1.14) (pull_request)
+      - ci / unit-tests (1.15) (pull_request)
+      - ci / unit-tests (1.16) (pull_request)
+      - ci / lint (pull_request)
       - cla/google
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,21 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_image:
-          - golang:1.11
-          - golang:1.12
-          - golang:1.13
-          - golang:1.14
-          - golang:1.15
-          - golang:1.16
-    container: ${{ matrix.docker_image }}
+        go_version:
+          - "1.11"
+          - "1.12"
+          - "1.13"
+          - "1.14"
+          - "1.15"
+          - "1.16"
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go_version }}
       - uses: actions/checkout@v2
       - run: go test -p 1 ./...
   lint:
     runs-on: ubuntu-latest
-    container: golang:1.16
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - uses: actions/checkout@v2
       - name: Install golangci-lint
         run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest


### PR DESCRIPTION
Moves CI off of using Docker images to plain ubuntu + Go. The docker images are community maintained and older images have expired certs.

In doing so, the names of checks have changed, so the `sync-repo-settings` must be updated here and manually in the repo settings.