### PR TITLE
chore(ci): switch golangci-lint to action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.16"
+          go-version: 1.16
       - uses: actions/checkout@v3
-      - name: Install golangci-lint
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-      - name: Run golangci-lint
-        run: golangci-lint run ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Previously usage of this tool was by downloading a bash script (kind of risky) and for whatever reason it stopped working. Just switching to the Action form as it is more idiomatic and will probably just work.